### PR TITLE
Adding second entry point for git to discover

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "./index.js"
   ],
   "bin": {
-    "add-gitignore": "./index.js"
+    "add-gitignore": "./index.js",
+    "git-addignore": "./index.js"
   },
   "dependencies": {
     "chalk": "^2.4.1",


### PR DESCRIPTION
# In this PR

Closes #3 

## For discussion:

We could make the script automatically work on the .gitignore file in the git root directory? Currently it always affects the current working directory.
